### PR TITLE
Fix risk factors screen

### DIFF
--- a/src/store/modules/api.js
+++ b/src/store/modules/api.js
@@ -81,7 +81,9 @@ export default {
 
     addRiskFactors({commit}, {riskFactors, data}) {
       data.forEach((factor) => {
-        if (riskFactors.includes(factor.id)) commit('PUSH_RISK_FACTOR', factor);
+        if (riskFactors.includes(factor.id)) {
+          commit('PUSH_RISK_FACTOR', factor);
+        }
       });
     },
 

--- a/src/store/modules/api.js
+++ b/src/store/modules/api.js
@@ -80,9 +80,9 @@ export default {
     },
 
     addRiskFactors({commit}, {riskFactors, data}) {
-      data
-        .filter((factor) => riskFactors.includes(factor.id))
-        .map((factor) => commit('PUSH_RISK_FACTOR', factor));
+      data.forEach((factor) => {
+        if (riskFactors.includes(factor.id)) commit('PUSH_RISK_FACTOR', factor);
+      });
     },
 
     selectRiskFactors({dispatch, getters}, riskFactors) {

--- a/src/store/modules/api.js
+++ b/src/store/modules/api.js
@@ -80,11 +80,9 @@ export default {
     },
 
     addRiskFactors({commit}, {riskFactors, data}) {
-      data.find((factor) => {
-        if (riskFactors.includes(factor.id)) {
-          commit('PUSH_RISK_FACTOR', factor);
-        }
-      });
+      data
+        .filter((factor) => riskFactors.includes(factor.id))
+        .map((factor) => commit('PUSH_RISK_FACTOR', factor));
     },
 
     selectRiskFactors({dispatch, getters}, riskFactors) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,7 +14,7 @@ export const arrayContains = (array, object) => {
 export const mapRiskFactors = (constFactors, riskFactors) => {
   return constFactors.map((factorId) => {
     const index = findIndex(riskFactors, factorId);
-    if (index < 0) return;
+    if (index < 0) return null;
 
     return {
       id: riskFactors[index].id,

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,12 +14,14 @@ export const arrayContains = (array, object) => {
 export const mapRiskFactors = (constFactors, riskFactors) => {
   return constFactors.map((factorId) => {
     const index = findIndex(riskFactors, factorId);
+    if (index < 0) return;
+
     return {
       id: riskFactors[index].id,
       common_name: riskFactors[index].common_name,
       category: riskFactors[index].category
     };
-  });
+  }).filter((riskFactor) => !!riskFactor);
 };
 
 export const selectedEvidences = (evidencesGetter, evidences) => {


### PR DESCRIPTION
Currently risk factors takes predetermined risks from `constants` file, loads risks from API and matches them. It looks like `p_147` (physical injury) is no longer sent or changed id, so `mapRiskFactors` was trying to get values that didn't exist. With this fix it's not longer happening.
